### PR TITLE
remove VOLUME /var/www/html

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,6 @@ COPY run-lap.sh /usr/sbin/
 RUN chmod +x /usr/sbin/run-lap.sh
 RUN chown -R apache:apache /var/www/html
 
-VOLUME /var/www/html
 VOLUME /var/log/httpd
 
 EXPOSE 80


### PR DESCRIPTION
It is not possible to change the permissions of a directory in Docker, after it has been declared a volume.

Something like : 
COPY /my/site/data /var/www/html
 doesn't really work, as root will own the files. 